### PR TITLE
Enable specifying directionality in binding-dissociation reaction via arrow types

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ _An enzyme, E, binding to a substrate, S, to form a complex, ES, which in turn r
 1. Prepare a text file describing the biochemical reactions (e.g., `michaelis_menten.txt`)
 
    ```
-   E binds S <--> ES | kf=0.003, kr=0.001 | E=100, S=50
-   ES dissociates to E and P | kf=0.002, kr=0
+   E + S ⇄ ES | kf=0.003, kr=0.001 | E=100, S=50
+   ES → E + P | kf=0.002
 
    @obs Substrate: u[S]
    @obs E_free: u[E]

--- a/docs/modules/reaction_rules.rst
+++ b/docs/modules/reaction_rules.rst
@@ -2,6 +2,6 @@ Available reaction rules (:py:mod:`pasmopy.construction.reaction_rules`)
 ------------------------------------------------------------------------
 
 .. autoclass:: pasmopy.construction.reaction_rules.ReactionRules
-   :members: dimerize, bind, is_dissociated, is_phosphorylated, is_dephosphorylated, phosphorylate, dephosphorylate, transcribe, is_translated, synthesize, is_synthesized, degrade, is_degraded, translocate
+   :members: _bind_and_dissociate, dimerize, bind, is_dissociated, is_phosphorylated, is_dephosphorylated, phosphorylate, dephosphorylate, transcribe, is_translated, synthesize, is_synthesized, degrade, is_degraded, translocate
    :member-order: bysource
 

--- a/pasmopy/construction/reaction_rules.py
+++ b/pasmopy/construction/reaction_rules.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Dict, List, NamedTuple, Optional
@@ -53,13 +52,13 @@ class ReactionRules(ThermodynamicRestrictions):
         * - Rule
           - Example sentence
           - Parameters (optional)
-        * - :func:`~pasmopy.construction.reaction_rules.dimerize`
+        * - :func:`~pasmopy.construction.reaction_rules.dimerize`\*
           - *A* dimerizes <--> *AA*
           - .. math:: kf, kr
-        * - :func:`~pasmopy.construction.reaction_rules.bind`
+        * - :func:`~pasmopy.construction.reaction_rules.bind`\*
           - *A* binds *B* <--> *AB*
           - .. math:: kf, kr
-        * - :func:`~pasmopy.construction.reaction_rules.dissociate`
+        * - :func:`~pasmopy.construction.reaction_rules.dissociate`\*
           - *AB* dissociates to *A* and *B*
           - .. math:: kf, kr
         * - :func:`~pasmopy.construction.reaction_rules.is_phosphorylated`
@@ -95,6 +94,13 @@ class ReactionRules(ThermodynamicRestrictions):
         * - :func:`~pasmopy.construction.reaction_rules.translocate`
           - *Acyt* translocates from cytoplasm to nucleus (Vcyt, Vnuc) <--> *Anuc*
           - .. math:: kf, kr, (V_{pre}, V_{post})
+
+    \* From v0.2.2, you can specify directionality in binding-dissociation reaction via different arrows:
+
+    .. code-block:: python
+
+        E + S ⇄ ES | kf=0.003, kr=0.001 | E=100, S=50  # bi-directional
+        ES → E + P | kf=0.002  # unidirectional
 
     Attributes
     ----------

--- a/pasmopy/construction/reaction_rules.py
+++ b/pasmopy/construction/reaction_rules.py
@@ -486,71 +486,95 @@ class ReactionRules(ThermodynamicRestrictions):
                 return sentence[: -len(preposition) - 1]
         return sentence
 
+    @staticmethod
+    def _is_unidirectional(arrow: str) -> bool:
+        """
+        Check if a reaction is unidirectional or not.
+        """
+        return True if arrow.strip().startswith("<") and arrow.strip().endswith(">") else False
+
+
     def _bind_and_dissociate(self, line_num: int, line: str) -> None:
         """
-        See examples in :func:`bind` and :func:`dissociate`.
+        Examples
+        --------
+        >>> 'A + B --> AB'  # bind, unidirectional
+        >>> 'AB --> A + B'  # dissociate, unidirectional
+        >>> 'A + B <--> AB' # bind and dissociate, bidirectional
         """
         description = self._preprocessing(
             sys._getframe().f_code.co_name, line_num, line, "kf", "kr"
         )
-        is_bind: bool
-        if " <--> " in description[1]:
-            is_bind = True
-            component1 = description[0].strip(" ")
-            component2 = description[1].split(" <--> ")[0].strip(" ")
-            complex = description[1].split(" <--> ")[1].strip(" ")
-        elif " <--> " in description[0]:
-            is_bind = False
-            component1 = description[0].split(" <--> ")[1].strip(" ")
-            component2 = description[1].strip(" ")
-            complex = description[0].split(" <--> ")[0].strip(" ")
+        is_binding: bool
+        unidirectional: bool
+        arrows = [" <--> ", " --> "]
+        for arrow in arrows:
+            if arrow in description[1]:
+                is_binding = True
+                unidirectional = self._is_unidirectional(arrow)
+                component1 = description[0].strip(" ")
+                component2 = description[1].split(arrow)[0].strip(" ")
+                complex = description[1].split(arrow)[1].strip(" ")
+                break
+            elif arrow in description[0]:
+                is_binding = False
+                unidirectional = self._is_unidirectional(arrow)
+                component1 = description[0].split(arrow)[1].strip(" ")
+                component2 = description[1].strip(arrow)
+                complex = description[0].split(arrow)[0].strip(" ")
+                break
         else:
             raise ValueError(
-                f"line{line_num:d}: Use '<-->' for reversible reaction rules."
+                f"line{line_num:d}: Use '<-->' or '-->'."
             )
         if component1 == complex or component2 == complex:
             raise ValueError(f"line{line_num:d}: {complex} <- Use a different name.")
         else:
             self._set_species(component1, component2, complex)
             self.complex_formations.append(
-                ComplexFormation(line_num, set([component1, component2]), complex, True)
+                ComplexFormation(line_num, set([component1, component2]), complex, is_binding)
             )
             self.reactions.append(
                 f"v[{line_num:d}] = "
-                f"x[C.kf{line_num:d}] * y[V.{component1}] * y[V.{component2}] - "
-                f"x[C.kr{line_num:d}] * y[V.{complex}]"
-                if is_bind else
+                f"x[C.kf{line_num:d}] * y[V.{component1}] * y[V.{component2}]"
+                + (
+                    f" - x[C.kr{line_num:d}] * y[V.{complex}]" if not unidirectional else ""
+                )
+                if is_binding else
                 f"v[{line_num:d}] = "
-                f"x[C.kf{line_num:d}] * y[V.{complex}] - "
-                f"x[C.kr{line_num:d}] * y[V.{component1}] * y[V.{component2}]"
+                f"x[C.kf{line_num:d}] * y[V.{complex}]"
+                + (
+                    f" - x[C.kr{line_num:d}] * y[V.{component1}] * y[V.{component2}]"
+                    if not unidirectional else ""
+                )
             )
             counter_component1, counter_component2, counter_complex = (0, 0, 0)
             for i, eq in enumerate(self.differential_equations):
                 if f"dydt[V.{component1}]" in eq:
                     counter_component1 += 1
-                    self.differential_equations[i] = eq + (" - " if is_bind else " + ") + f"v[{line_num:d}]"
+                    self.differential_equations[i] = eq + (" - " if is_binding else " + ") + f"v[{line_num:d}]"
                 elif f"dydt[V.{component2}]" in eq:
                     counter_component2 += 1
-                    self.differential_equations[i] = eq + (" - " if is_bind else " + ") + f"v[{line_num:d}]"
+                    self.differential_equations[i] = eq + (" - " if is_binding else " + ") + f"v[{line_num:d}]"
                 elif f"dydt[V.{complex}]" in eq:
                     counter_complex += 1
-                    self.differential_equations[i] = eq + (" + " if is_bind else " - ") + f"v[{line_num:d}]"
+                    self.differential_equations[i] = eq + (" + " if is_binding else " - ") + f"v[{line_num:d}]"
             if counter_component1 == 0:
                 self.differential_equations.append(
                     f"dydt[V.{component1}] = - v[{line_num:d}]"
-                    if is_bind else
+                    if is_binding else
                     f"dydt[V.{component1}] = + v[{line_num:d}]"
                 )
             if counter_component2 == 0:
                 self.differential_equations.append(
                     f"dydt[V.{component2}] = - v[{line_num:d}]"
-                    if is_bind else
+                    if is_binding else
                     f"dydt[V.{component2}] = + v[{line_num:d}]"
                 )
             if counter_complex == 0:
                 self.differential_equations.append(
                     f"dydt[V.{complex}] = + v[{line_num:d}]"
-                    if is_bind else
+                    if is_binding else
                     f"dydt[V.{complex}] = - v[{line_num:d}]"
                 )
 

--- a/pasmopy/construction/reaction_rules.py
+++ b/pasmopy/construction/reaction_rules.py
@@ -202,6 +202,7 @@ class ReactionRules(ThermodynamicRestrictions):
                 " forms dimers",
             ],
             bind=[
+                " +",
                 " binds",
                 " forms complexes with",
             ],
@@ -548,6 +549,7 @@ class ReactionRules(ThermodynamicRestrictions):
         """
         Examples
         --------
+        >>> 'A + B <--> AB'
         >>> 'A binds B <--> AB'
         >>> 'A forms complexes with B <--> AB'
 
@@ -624,8 +626,8 @@ class ReactionRules(ThermodynamicRestrictions):
         """
         Examples
         --------
-        >>> 'AB dissociates to A and B'
-        >>> 'AB is dissociated into A and B'
+        >>> 'AB dissociates to A and(+) B'
+        >>> 'AB is dissociated into A and(+) B'
 
         Notes
         -----
@@ -645,17 +647,20 @@ class ReactionRules(ThermodynamicRestrictions):
                 d[AB]/dt = - v
 
         """
+        join_componets = [" and ", " + "]
         description = self._preprocessing(
             sys._getframe().f_code.co_name, line_num, line, "kf", "kr"
         )
         complex = description[0].strip(" ")
-        if " and " not in description[1]:
-            raise ValueError(
-                f"Use 'and' in line{line_num:d}:\ne.g., AB is dissociated into A and B"
-            )
+        for word in join_componets:
+            if word in description[1]:
+                component1 = description[1].split(word)[0].strip(" ")
+                component2 = description[1].split(word)[1].strip(" ")
+                break
         else:
-            component1 = description[1].split(" and ")[0].strip(" ")
-            component2 = description[1].split(" and ")[1].strip(" ")
+            raise ValueError(
+                f"Use 'and' or '+' in line{line_num:d}:\ne.g., AB is dissociated into A and(+) B"
+            )
         self._set_species(complex, component1, component2)
         self.complex_formations.append(
             ComplexFormation(line_num, set([component1, component2]), complex, False)

--- a/pasmopy/construction/reaction_rules.py
+++ b/pasmopy/construction/reaction_rules.py
@@ -258,17 +258,36 @@ class ReactionRules(ThermodynamicRestrictions):
     )
     fwd_arrows: List[str] = field(
         default_factory=lambda: [
-            " → ", " ↣ ", " ↦ ", " ⇾ ", " ⟶ ", " ⟼ ", " ⥟ ", " ⥟ ", " ⇀ ", " ⇁ ", " ⇒ ", " ⟾ ", " --> ",
+            " → ",
+            " ↣ ",
+            " ↦ ",
+            " ⇾ ",
+            " ⟶ ",
+            " ⟼ ",
+            " ⥟ ",
+            " ⥟ ",
+            " ⇀ ",
+            " ⇁ ",
+            " ⇒ ",
+            " ⟾ ",
+            " --> ",
         ],
         init=False,
     )
     double_arrows: List[str] = field(
         default_factory=lambda: [
-            " ↔ ", " ⟷ ", " ⇄ ", " ⇆ ", " ⇌ ", " ⇋ ", " ⇔ ", " ⟺ ", " <--> ",
+            " ↔ ",
+            " ⟷ ",
+            " ⇄ ",
+            " ⇆ ",
+            " ⇌ ",
+            " ⇋ ",
+            " ⇔ ",
+            " ⟺ ",
+            " <--> ",
         ],
         init=False,
     )
-
 
     def __post_init__(self) -> None:
         if not 0.0 < self.similarity_threshold < 1.0:
@@ -507,7 +526,6 @@ class ReactionRules(ThermodynamicRestrictions):
                 return sentence[: -len(preposition) - 1]
         return sentence
 
-
     def _bind_and_dissociate(self, line_num: int, line: str) -> None:
         """
         Examples
@@ -551,45 +569,50 @@ class ReactionRules(ThermodynamicRestrictions):
             self.reactions.append(
                 f"v[{line_num:d}] = "
                 f"x[C.kf{line_num:d}] * y[V.{component1}] * y[V.{component2}]"
-                + (
-                    f" - x[C.kr{line_num:d}] * y[V.{complex}]" if not is_unidirectional else ""
-                )
-                if is_binding else
-                f"v[{line_num:d}] = "
+                + (f" - x[C.kr{line_num:d}] * y[V.{complex}]" if not is_unidirectional else "")
+                if is_binding
+                else f"v[{line_num:d}] = "
                 f"x[C.kf{line_num:d}] * y[V.{complex}]"
                 + (
                     f" - x[C.kr{line_num:d}] * y[V.{component1}] * y[V.{component2}]"
-                    if not is_unidirectional else ""
+                    if not is_unidirectional
+                    else ""
                 )
             )
             counter_component1, counter_component2, counter_complex = (0, 0, 0)
             for i, eq in enumerate(self.differential_equations):
                 if f"dydt[V.{component1}]" in eq:
                     counter_component1 += 1
-                    self.differential_equations[i] = eq + (" - " if is_binding else " + ") + f"v[{line_num:d}]"
+                    self.differential_equations[i] = (
+                        eq + (" - " if is_binding else " + ") + f"v[{line_num:d}]"
+                    )
                 elif f"dydt[V.{component2}]" in eq:
                     counter_component2 += 1
-                    self.differential_equations[i] = eq + (" - " if is_binding else " + ") + f"v[{line_num:d}]"
+                    self.differential_equations[i] = (
+                        eq + (" - " if is_binding else " + ") + f"v[{line_num:d}]"
+                    )
                 elif f"dydt[V.{complex}]" in eq:
                     counter_complex += 1
-                    self.differential_equations[i] = eq + (" + " if is_binding else " - ") + f"v[{line_num:d}]"
+                    self.differential_equations[i] = (
+                        eq + (" + " if is_binding else " - ") + f"v[{line_num:d}]"
+                    )
             if counter_component1 == 0:
                 self.differential_equations.append(
                     f"dydt[V.{component1}] = - v[{line_num:d}]"
-                    if is_binding else
-                    f"dydt[V.{component1}] = + v[{line_num:d}]"
+                    if is_binding
+                    else f"dydt[V.{component1}] = + v[{line_num:d}]"
                 )
             if counter_component2 == 0:
                 self.differential_equations.append(
                     f"dydt[V.{component2}] = - v[{line_num:d}]"
-                    if is_binding else
-                    f"dydt[V.{component2}] = + v[{line_num:d}]"
+                    if is_binding
+                    else f"dydt[V.{component2}] = + v[{line_num:d}]"
                 )
             if counter_complex == 0:
                 self.differential_equations.append(
                     f"dydt[V.{complex}] = + v[{line_num:d}]"
-                    if is_binding else
-                    f"dydt[V.{complex}] = - v[{line_num:d}]"
+                    if is_binding
+                    else f"dydt[V.{complex}] = - v[{line_num:d}]"
                 )
 
     def dimerize(self, line_num: int, line: str) -> None:
@@ -840,7 +863,9 @@ class ReactionRules(ThermodynamicRestrictions):
             f"v[{line_num:d}] = "
             f"x[C.kf{line_num:d}] * y[V.{unphosphorylated_form}]"
             + (
-                f" - x[C.kr{line_num:d}] * y[V.{phosphorylated_form}]" if not is_unidirectional else ""
+                f" - x[C.kr{line_num:d}] * y[V.{phosphorylated_form}]"
+                if not is_unidirectional
+                else ""
             )
         )
         counter_unphosphorylated_form, counter_phosphorylated_form = (0, 0)

--- a/pasmopy/construction/reaction_rules.py
+++ b/pasmopy/construction/reaction_rules.py
@@ -626,8 +626,8 @@ class ReactionRules(ThermodynamicRestrictions):
         """
         Examples
         --------
-        >>> 'AB dissociates to A and(+) B'
-        >>> 'AB is dissociated into A and(+) B'
+        >>> 'AB dissociates to A and B'
+        >>> 'AB is dissociated into A and B'
 
         Notes
         -----
@@ -647,20 +647,17 @@ class ReactionRules(ThermodynamicRestrictions):
                 d[AB]/dt = - v
 
         """
-        join_componets = [" and ", " + "]
         description = self._preprocessing(
             sys._getframe().f_code.co_name, line_num, line, "kf", "kr"
         )
         complex = description[0].strip(" ")
-        for word in join_componets:
-            if word in description[1]:
-                component1 = description[1].split(word)[0].strip(" ")
-                component2 = description[1].split(word)[1].strip(" ")
-                break
-        else:
+        if " and " not in description[1]:
             raise ValueError(
-                f"Use 'and' or '+' in line{line_num:d}:\ne.g., AB is dissociated into A and(+) B"
+                f"Use 'and' in line{line_num:d}:\ne.g., AB is dissociated into A and B"
             )
+        else:
+            component1 = description[1].split(" and ")[0].strip(" ")
+            component2 = description[1].split(" and ")[1].strip(" ")
         self._set_species(complex, component1, component2)
         self.complex_formations.append(
             ComplexFormation(line_num, set([component1, component2]), complex, False)

--- a/pasmopy/construction/reaction_rules.py
+++ b/pasmopy/construction/reaction_rules.py
@@ -52,13 +52,13 @@ class ReactionRules(ThermodynamicRestrictions):
         * - Rule
           - Example sentence
           - Parameters (optional)
-        * - :func:`~pasmopy.construction.reaction_rules.dimerize`\*
+        * - :func:`~pasmopy.construction.reaction_rules.dimerize`
           - *A* dimerizes <--> *AA*
           - .. math:: kf, kr
-        * - :func:`~pasmopy.construction.reaction_rules.bind`\*
+        * - :func:`~pasmopy.construction.reaction_rules.bind`
           - *A* binds *B* <--> *AB*
           - .. math:: kf, kr
-        * - :func:`~pasmopy.construction.reaction_rules.dissociate`\*
+        * - :func:`~pasmopy.construction.reaction_rules.dissociate`
           - *AB* dissociates to *A* and *B*
           - .. math:: kf, kr
         * - :func:`~pasmopy.construction.reaction_rules.is_phosphorylated`
@@ -95,7 +95,7 @@ class ReactionRules(ThermodynamicRestrictions):
           - *Acyt* translocates from cytoplasm to nucleus (Vcyt, Vnuc) <--> *Anuc*
           - .. math:: kf, kr, (V_{pre}, V_{post})
 
-    \* From v0.2.2, you can specify directionality in binding-dissociation reaction via different arrows:
+    From v0.2.2, you can specify directionality in binding-dissociation reaction via different arrows:
 
     .. code-block:: python
 

--- a/pasmopy/construction/text2model.py
+++ b/pasmopy/construction/text2model.py
@@ -849,6 +849,7 @@ class Text2Model(ReactionRules):
         terminology: Optional[
             Dict[
                 Literal[
+                    "_bind_and_dissociate",
                     "dimerize",
                     "bind",
                     "dissociate",

--- a/tests/text_files/abc.txt
+++ b/tests/text_files/abc.txt
@@ -1,4 +1,4 @@
-A binds B <--> AB
-AB binds C <--> ABC
-ABC dissociates to A and BC
-BC dissociates to B and C
+A + B <--> AB
+AB + C <--> ABC
+ABC <--> A + BC
+BC <--> B + C

--- a/tests/text_files/duplicate_binding.txt
+++ b/tests/text_files/duplicate_binding.txt
@@ -1,2 +1,2 @@
 A + B <--> AB
-AB dissociates to A and B
+AB <--> A + B

--- a/tests/text_files/duplicate_binding.txt
+++ b/tests/text_files/duplicate_binding.txt
@@ -1,2 +1,2 @@
-A binds B <--> AB
-AB dissociates to A and B
+A + B <--> AB
+AB dissociates to A + B

--- a/tests/text_files/duplicate_binding.txt
+++ b/tests/text_files/duplicate_binding.txt
@@ -1,2 +1,2 @@
 A + B <--> AB
-AB dissociates to A + B
+AB dissociates to A and B


### PR DESCRIPTION
- Close #64 

- Most arrows accepted.

  - Unidirectional: `" → ", " ↣ ", " ↦ ", " ⇾ ", " ⟶ ", " ⟼ ", " ⥟ ", " ⥟ ", " ⇀ ", " ⇁ ", " ⇒ ", " ⟾ ", " --> "`
  - Bi-directional: `" ↔ ", " ⟷ ", " ⇄ ", " ⇆ ", " ⇌ ", " ⇋ ", " ⇔ ", " ⟺ ", " <--> "`

- Now it is possible to build a Michaelis-Menten two-step enzyme catalysis model as follows:

> E + S ⇄ ES → E + P

```
E + S <--> ES | kf=0.003, kr=0.001 | E=100, S=50
ES --> E + P | kf=0.002

@obs Substrate: u[S]
@obs E_free: u[E]
@obs E_total: u[E] + u[ES]
@obs Product: u[P]
@obs Complex: u[ES]

@sim tspan: [0, 100]
```

[![michaelis_menten](https://raw.githubusercontent.com/pasmopy/pasmopy/master/docs/_static/img/michaelis_menten_sim.png)](https://pasmopy.readthedocs.io/en/latest/model_development.html#michaelis-menten-enzyme-kinetics)