### PR TITLE
Update `to_markdown` in `Text2Model`

### DIFF
--- a/pasmopy/construction/text2model.py
+++ b/pasmopy/construction/text2model.py
@@ -816,7 +816,7 @@ class Text2Model(ReactionRules):
         ) as f:
             f.writelines(
                 [
-                    "|No.|Reactions|Rate equations|\n|---|---------|--------------|\n",
+                    "|No.|Description|Rate|\n|---|-----------|----|\n",
                     *lines[:n_reaction],
                 ]
             )

--- a/pasmopy/construction/text2model.py
+++ b/pasmopy/construction/text2model.py
@@ -755,7 +755,7 @@ class Text2Model(ReactionRules):
                 for restriction in self.restrictions:
                     print("{" + ", ".join(restriction) + "}")
 
-    def to_markdown(self, n_reaction: int) -> None:
+    def to_markdown(self, n_reaction: int, savedir: str = "markdown") -> None:
         """
         Create markdown table describing differential equations.
 
@@ -763,6 +763,8 @@ class Text2Model(ReactionRules):
         ----------
         n_reaction : int
             The number of rate equations in the model.
+        savedir : str (default: "markdown")
+            The directory name to save the output.
 
         Examples
         --------
@@ -770,7 +772,7 @@ class Text2Model(ReactionRules):
         >>> Text2Model("Kholodenko1999.txt").to_markdown(25)
 
         """
-        os.makedirs(os.path.join("markdown", f"{self.name.split(os.sep)[-1]}"), exist_ok=True)
+        os.makedirs(os.path.join(savedir, f"{self.name.split(os.sep)[-1]}"), exist_ok=True)
         self.create_ode()
         with open(self.input_txt, encoding="utf-8") as f:
             lines = f.readlines()
@@ -796,14 +798,19 @@ class Text2Model(ReactionRules):
                                 f"{num + 1:d}", f"<sub>{num + 1:d}</sub>"
                             ),
                         )
+                reaction = line.split("|")[0].rstrip()
+                if reaction.startswith("@rxn "):
+                    reaction = self._remove_prefix(
+                        reaction, "@rxn "
+                    ).split(":")[0].strip()
                 lines[num] = (
                     f"|{num + 1:d}|"
-                    + line.split("|")[0].rstrip()
+                    + reaction
                     + f"|{rate_equation_formatted.replace('*', '·').replace('y[V.', '[')}|"
                     + "\n"
                 )
         with open(
-            os.path.join("markdown", f"{self.name.split(os.sep)[-1]}", "rate_equation.md"),
+            os.path.join(savedir, f"{self.name.split(os.sep)[-1]}", "rate_equation.md"),
             encoding="utf-8",
             mode="w",
         ) as f:
@@ -833,7 +840,7 @@ class Text2Model(ReactionRules):
                     )
             differential_equations_formatted[i] = eq + "|\n"
         with open(
-            os.path.join("markdown", f"{self.name.split(os.sep)[-1]}", "differential_equation.md"),
+            os.path.join(savedir, f"{self.name.split(os.sep)[-1]}", "differential_equation.md"),
             encoding="utf-8",
             mode="w",
         ) as f:

--- a/pasmopy/construction/text2model.py
+++ b/pasmopy/construction/text2model.py
@@ -810,7 +810,7 @@ class Text2Model(ReactionRules):
                     + "\n"
                 )
         with open(
-            os.path.join(savedir, f"{self.name.split(os.sep)[-1]}", "rate_equation.md"),
+            os.path.join(savedir, f"{self.name.split(os.sep)[-1]}", "rate.md"),
             encoding="utf-8",
             mode="w",
         ) as f:
@@ -840,7 +840,7 @@ class Text2Model(ReactionRules):
                     )
             differential_equations_formatted[i] = eq + "|\n"
         with open(
-            os.path.join(savedir, f"{self.name.split(os.sep)[-1]}", "differential_equation.md"),
+            os.path.join(savedir, f"{self.name.split(os.sep)[-1]}", "diffeq.md"),
             encoding="utf-8",
             mode="w",
         ) as f:

--- a/pasmopy/construction/text2model.py
+++ b/pasmopy/construction/text2model.py
@@ -800,9 +800,7 @@ class Text2Model(ReactionRules):
                         )
                 reaction = line.split("|")[0].rstrip()
                 if reaction.startswith("@rxn "):
-                    reaction = self._remove_prefix(
-                        reaction, "@rxn "
-                    ).split(":")[0].strip()
+                    reaction = self._remove_prefix(reaction, "@rxn ").split(":")[0].strip()
                 lines[num] = (
                     f"|{num + 1:d}|"
                     + reaction

--- a/tests/test_model_construction.py
+++ b/tests/test_model_construction.py
@@ -132,8 +132,8 @@ def test_text2markdown():
                 )
             )
             mapk_cascade.to_markdown(n_reaction=25)
-        assert os.path.isfile(os.path.join("markdown", model, "rate_equation.md"))
-        assert os.path.isfile(os.path.join("markdown", model, "differential_equation.md"))
+        assert os.path.isfile(os.path.join("markdown", model, "rate.md"))
+        assert os.path.isfile(os.path.join("markdown", model, "diffeq.md"))
         shutil.rmtree("markdown")
 
 


### PR DESCRIPTION
This update addresses #81.

Example of [fos_model](https://github.com/pasmopy/pasmopy/blob/master/tests/text_files/fos_model.txt):

|No.|Description|Rate|
|---|---|---|
|1|ERKc --> pERKc|V<sub>1</sub> · a · [ppMEKc] · [ERKc] / ( K<sub>1</sub> · (1 + [pERKc] / K2) + [ERKc] )|
|2|pERKc --> ppERKc|V<sub>2</sub> · a · [ppMEKc] · [pERKc] / ( K<sub>2</sub> · (1 + [ERKc] / K1) + [pERKc] )|
|3|pERKc --> ERKc|V<sub>3</sub> · [pERKc] / ( K<sub>3</sub> · (1 + [ppERKc] / K4) + [pERKc] )|
|4|ppERKc --> pERKc|V<sub>4</sub> · [ppERKc] / ( K<sub>4</sub>· (1 + [pERKc] / K3) + [ppERKc] )|
|5|pERKn --> ERKn|V<sub>5</sub> · [pERKn] / ( K<sub>5</sub> · (1 + [ppERKn] / K6) + [pERKn] )|
|6|ppERKn --> pERKn|V<sub>6</sub> · [ppERKn] / ( K<sub>6</sub> · (1 + [pERKn] / K5) + [ppERKn] )|